### PR TITLE
deploy: публикация сайта на printwizard.ru через Yandex Object Storage

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,61 +1,108 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: Deploy site
 
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages
+# Собирает Jekyll-сайт двумя независимыми сборками:
+#   1) build-yc  — для printwizard.ru (baseurl="")            → Yandex Object Storage + CDN purge.
+#   2) build-gh  — для vandalsvq.github.io/printwizard         → GitHub Pages (зеркало).
+# Сборки параллельны и независимы: если падает одна — вторая всё равно доезжает.
 
 on:
   push:
     branches: ["master"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
 concurrency:
-  group: "pages"
+  group: "deploy-site"
   cancel-in-progress: true
 
 jobs:
-  # Build job
-  build:
+  build-yc:
+    name: Build & deploy to Yandex Object Storage
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          ruby-version: '3.3'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Build with Jekyll (baseurl="")
+        run: bundle exec jekyll build --baseurl "" --destination _site_yc
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy to Object Storage (s3 sync)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.YC_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.YC_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ru-central1
+        run: |
+          aws s3 sync _site_yc/ s3://printwizard.ru/ \
+            --endpoint-url=https://storage.yandexcloud.net \
+            --delete \
+            --exact-timestamps
+
+      - name: Install yc CLI
+        run: |
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash -s -- -i ${HOME}/yc -n
+          echo "${HOME}/yc/bin" >> $GITHUB_PATH
+
+      - name: Configure yc CLI
+        env:
+          YC_SA_KEY: ${{ secrets.YC_SA_KEY_JSON }}
+        run: |
+          echo "$YC_SA_KEY" > /tmp/yc-sa-key.json
+          yc config set service-account-key /tmp/yc-sa-key.json
+
+      - name: Purge CDN cache
+        env:
+          YC_CDN_RESOURCE_ID: ${{ secrets.YC_CDN_RESOURCE_ID }}
+        run: |
+          yc cdn cache purge --resource-id "$YC_CDN_RESOURCE_ID" --paths '/*'
+
+      - name: Cleanup credentials
+        if: always()
+        run: rm -f /tmp/yc-sa-key.json
+
+  build-gh:
+    name: Build & deploy to GitHub Pages (mirror)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          cache-version: 0
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
+
+      - name: Build with Jekyll (baseurl from Pages)
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+
       - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
 
-  # Deployment job
-  deploy:
+  deploy-gh:
+    name: Deploy GitHub Pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-gh
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Infostart PrintWizard – это простое и функциональное 
 ## Полезные ссылки
 
 * [Infostart Marketplace](https://infostart.ru/marketplace/1918555/)
-* [Сайт с документацией](https://vandalsvq.github.io/printwizard/)
+* [Сайт с документацией](https://printwizard.ru/) (зеркало: [vandalsvq.github.io/printwizard](https://vandalsvq.github.io/printwizard/))
 * [Новости в телеграм-канале](https://t.me/isprintwizard)
 
 ## Community-версия
@@ -41,7 +41,7 @@ Infostart PrintWizard – это простое и функциональное 
 
 ## Документация
 
-Источник истины пользовательской документации — [`/docs`](docs/) (Jekyll, публикуется на [vandalsvq.github.io/printwizard](https://vandalsvq.github.io/printwizard/)). Машиночитаемая копия для AI-агента — [`/docs-llm`](docs-llm/), генерируется автоматически.
+Источник истины пользовательской документации — [`/docs`](docs/) (Jekyll, публикуется на [printwizard.ru](https://printwizard.ru/) и зеркалится на [vandalsvq.github.io/printwizard](https://vandalsvq.github.io/printwizard/)). Машиночитаемая копия для AI-агента — [`/docs-llm`](docs-llm/), генерируется автоматически.
 
 **Локально ничего запускать не нужно.** Правьте только `/docs`, открывайте PR. После merge в master GitHub Action [`docs-llm build`](.github/workflows/docs-llm-build.yml) запустит генератор и автоматически закоммитит обновлённый `/docs-llm` в master.
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: PrintWizard
 description: Расширение для конфигураций 1С
 theme: just-the-docs
 
-url: https://vandalsvq.github.io/printwizard
+url: https://printwizard.ru
 repository: vandalsvq/printwizard
 
 defaults:


### PR DESCRIPTION
## Summary

- Сайт начинает публиковаться на новом основном адресе `https://printwizard.ru` через Yandex Object Storage + CDN.
- GitHub Pages (`vandalsvq.github.io/printwizard`) сохраняется как зеркало — на случай проблем с RU-инфраструктурой.
- Workflow разделён на две независимые сборки: падение одной не блокирует другую.

## Что меняется

| Файл | Что |
|---|---|
| `_config.yml` | `url` → `https://printwizard.ru` (canonical теперь указывает на основной домен) |
| `.github/workflows/jekyll.yml` | две параллельные сборки: `build-yc` (S3 + CDN purge) и `build-gh` (GitHub Pages) |
| `README.md` | обновлены ссылки на сайт |

## Требуется (уже настроено)

В Yandex Cloud:
- Бакет `printwizard.ru` со статическим хостингом
- Сервисный аккаунт `github-actions-deploy` с ролями `storage.editor` + `cdn.editor`
- CDN-ресурс перед бакетом
- Авторизованный JSON-ключ сервисного аккаунта

В GitHub Secrets:
- `YC_S3_ACCESS_KEY_ID`, `YC_S3_SECRET_ACCESS_KEY` — для `aws s3 sync`
- `YC_SA_KEY_JSON` — для `yc cdn cache purge`
- `YC_CDN_RESOURCE_ID` — ID CDN-ресурса

## Что НЕ входит в этот PR

- DNS-делегирование `printwizard.ru` на Yandex Cloud DNS (ждём активации в nic.ru).
- TLS-сертификат и привязка к CDN (после делегирования).
- Редирект `HTTP → HTTPS` в CDN (после сертификата).

После merge сайт сразу будет доступен по адресам:
- `https://printwizard.ru.website.yandexcloud.net` — S3-endpoint бакета
- `https://vandalsvq.github.io/printwizard/` — зеркало на GitHub Pages

## Test plan

- [ ] PR проходит CI (оба job-а зелёные)
- [ ] После merge `build-yc` загружает `_site_yc/` в бакет
- [ ] `Purge CDN cache` отрабатывает без ошибки
- [ ] Открыть `https://printwizard.ru.website.yandexcloud.net` — видим главную страницу
- [ ] `build-gh` параллельно публикует на GitHub Pages, зеркало остаётся актуальным