### PR TITLE
fix(deploy): убрать неподдерживаемый флаг --paths из yc cdn cache purge

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           YC_CDN_RESOURCE_ID: ${{ secrets.YC_CDN_RESOURCE_ID }}
         run: |
-          yc cdn cache purge --resource-id "$YC_CDN_RESOURCE_ID" --paths '/*'
+          yc cdn cache purge --resource-id "$YC_CDN_RESOURCE_ID"
 
       - name: Cleanup credentials
         if: always()


### PR DESCRIPTION
## Что и зачем

Workflow `Deploy site` падал на шаге `Purge CDN cache` с ошибкой:

```
ERROR: unknown flag: --paths
```

У текущей версии `yc` CLI этого флага нет. Без флага команда чистит **весь** кеш ресурса — это ровно то, что нам нужно после каждого деплоя.

S3 sync в этом же прогоне уже отрабатывал успешно, так что после merge ожидаем полностью зелёный workflow.

## Test plan

- [ ] После merge workflow `Deploy site` зелёный целиком
- [ ] `Purge CDN cache` отрабатывает за пару секунд
- [ ] Открыть `https://printwizard.ru.website.yandexcloud.net/` — обновлённая главная страница