### PR TITLE
fix(deploy): yc cdn cache purge требует --all

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           YC_CDN_RESOURCE_ID: ${{ secrets.YC_CDN_RESOURCE_ID }}
         run: |
-          yc cdn cache purge --resource-id "$YC_CDN_RESOURCE_ID"
+          yc cdn cache purge --resource-id "$YC_CDN_RESOURCE_ID" --all
 
       - name: Cleanup credentials
         if: always()


### PR DESCRIPTION
## Что и зачем

Прошлый фикс (#259) убрал несуществующий флаг `--paths`, но без флагов yc CLI отказывается работать:

```
ERROR: exactly one of '--path' or '--all' should be set, but nothing is set
```

Используем `--all` — это очищает весь кеш ресурса, что нужно после каждого деплоя.

## Test plan

- [ ] После merge `Deploy site` зелёный целиком
- [ ] `Purge CDN cache` отрабатывает успешно