### PR TITLE
SEO: Яндекс.Метрика (счётчик 109784676)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,21 @@ export default defineConfig({
         { tag: 'meta', attrs: { property: 'og:type', content: 'website' } },
         { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
         { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://printwizard.ru/og.png' } },
+        // Яндекс.Метрика (счётчик 109784676) — на всех страницах документации.
+        {
+          tag: 'script',
+          content: `(function(m,e,t,r,i,k,a){
+        m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+        m[i].l=1*new Date();
+        for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+        k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+    })(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=109784676', 'ym');
+    ym(109784676, 'init', {ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", referrer: document.referrer, url: location.href, accurateTrackBounce:true, trackLinks:true});`,
+        },
+        {
+          tag: 'noscript',
+          content: '<div><img src="https://mc.yandex.ru/watch/109784676" style="position:absolute; left:-9999px;" alt="" /></div>',
+        },
       ],
       defaultLocale: 'root',
       locales: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -209,6 +209,19 @@ const jsonLd = {
     />
     <meta name="twitter:image" content="https://printwizard.ru/og.png" />
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+    <!-- Yandex.Metrika counter -->
+    <script is:inline type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=109784676', 'ym');
+
+        ym(109784676, 'init', {ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", referrer: document.referrer, url: location.href, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/109784676" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
   </head>
   <body>
     <header class="site-header">


### PR DESCRIPTION
Подключает Яндекс.Метрику на **все** страницы:
- лендинг — `<head>` `src/pages/index.astro` (`is:inline`, скрипт не бандлится);
- документация — массив `head` в `astro.config.mjs` (Starlight инжектит на все страницы).

Включены Вебвизор, карта кликов, точный показатель отказов, отслеживание ссылок. Добавлен `<noscript>`-фолбэк.

Проверено сборкой: сниппет присутствует и в `dist/index.html`, и в `dist/guide/index.html`.

⚠️ Merge в master запускает боевой деплой (Yandex Object Storage + сброс CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)