### PR TITLE
ci: обновить версии GitHub Actions на Node 24

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -25,10 +25,10 @@ jobs:
     name: Build & deploy to Yandex Object Storage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -76,11 +76,11 @@ jobs:
     name: Build GitHub Pages stub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload stub artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: gh-pages-stub
 
@@ -94,4 +94,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
GitHub выводит из эксплуатации Node 20 у actions (форс на Node 24 с 16.06.2026, ранее были предупреждения в логах деплоя). Обновлены до актуальных мажорных версий:

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/configure-pages` v5 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5

Это официальные GitHub-экшены, апгрейд мажорных версий устраняет deprecation. Реальная проверка — запуск `deploy-site.yml` на merge (workflow гоняется только в CI).

⚠️ Merge в master запускает боевой деплой (Yandex Object Storage + сброс CDN) — заодно прогонит обновлённый workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)