### PR TITLE
docs-llm: зарегистрировать guide/libreoffice.md (фикс упавшей сборки)

### DIFF
--- a/tools/docs-llm/topics.json
+++ b/tools/docs-llm/topics.json
@@ -94,6 +94,10 @@
     "prefix": "техподдержка",
     "summary_prefix": "Техническая поддержка"
   },
+  "guide/libreoffice.md": {
+    "prefix": "libreoffice",
+    "summary_prefix": "Установка LibreOffice"
+  },
   "guide/ch-09-01.md": {
     "prefix": "установка",
     "summary_prefix": "Установка"


### PR DESCRIPTION
## Проблема

Сборка `docs-llm` падала с ошибкой валидатора покрытия:

```
Uncovered file: guide/libreoffice.md (добавьте в topics.json или excluded.json)
```

Новая страница «Установка LibreOffice» ([src/content/docs/guide/libreoffice.md](src/content/docs/guide/libreoffice.md), pw-231) не была классифицирована ни в `topics.json`, ни в `excluded.json`. По правилу проекта каждый файл в `src/content/docs` обязан быть в одном из двух.

## Решение

Зарегистрировал файл в [tools/docs-llm/topics.json](tools/docs-llm/topics.json) — именно **индексирую**, а не исключаю: инструкция по установке LibreOffice полезна для встроенного AI-ассистента. Префикс `установка` уже занят главой ch-09-01, поэтому взят отдельный `libreoffice`.

Артефакты `/docs-llm` в этот PR намеренно **не** включены — их пересоберёт авто-мержащийся бот-PR после merge в `master`.

## Проверка

- `python3 tools/docs-llm/build.py --check` — OK (topics 137 → 143)
- `python3 -m unittest discover tests` — 32/32 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)